### PR TITLE
Update user and group, add security protections

### DIFF
--- a/debian/peach-oled.service
+++ b/debian/peach-oled.service
@@ -3,11 +3,28 @@ Description=JSON-RPC microservice for writing and drawing to an OLED display ove
 
 [Service]
 Type=simple
-User=root
-Group=root
+User=peach-oled
+Group=i2c-user
 Environment="RUST_LOG=error"
 ExecStart=/usr/bin/peach-oled
 Restart=always
+CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYS_BOOT CAP_SYS_TIME CAP_KILL CAP_WAKE_ALARM CAP_LINUX_IMMUTABLE CAP_BLOCK_SUSPEND CAP_LEASE CAP_SYS_NICE CAP_SYS_RESOURCE CAP_RAWIO CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_* CAP_FOWNER CAP_IPC_OWNER CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_AUDIT_*
+InaccessibleDirectories=/home
+IPAddressDeny=~127.0.0.1
+LockPersonality=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateUsers=yes
+ProtectControlGroups=yes
+ProtectDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=yes
+ReadOnlyDirectories=/var
+RestrictAddressFamilies=~AF_INET6 AF_UNIX
+RestrictNamespaces=~CLONE_NEWUSER
+SystemCallFilter=~@reboot @clock @debug @module @mount @swap @resources @privileged
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The systemd unit file has been updated to run the daemon as the peach-oled user in the i2c-user group. This removes the previously-insecure iteration which ran the service as the root user.

This PR also adds a number of security-related protections to limit the capabilities of the service.