### PR TITLE
Remove extern statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-oled
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-oled.svg?branch=master)](https://travis-ci.com/peachcloud/peach-oled) ![Generic badge](https://img.shields.io/badge/version-0.1.0-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-oled.svg?branch=master)](https://travis-ci.com/peachcloud/peach-oled) ![Generic badge](https://img.shields.io/badge/version-0.1.1-<COLOR>.svg)
 
 OLED microservice module for PeachCloud. Write to a 128x64 OLED display with SDD1306 driver (I2C) using [JSON-RPC](https://www.jsonrpc.org/specification) over http.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,7 @@
-extern crate linux_embedded_hal as hal;
-
 use std::error;
 
 use jsonrpc_core::{types::error::Error, ErrorCode};
+use linux_embedded_hal as hal;
 use snafu::Snafu;
 
 pub type BoxError = Box<dyn error::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,3 @@
-#[macro_use]
-extern crate log;
-extern crate embedded_graphics;
-extern crate linux_embedded_hal as hal;
-extern crate ssd1306;
-
 mod error;
 
 use std::{
@@ -21,6 +15,8 @@ use jsonrpc_core::{types::error::Error, IoHandler, Params, Value};
 use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder};
 #[allow(unused_imports)]
 use jsonrpc_test as test;
+use linux_embedded_hal as hal;
+use log::{debug, error, info};
 use serde::Deserialize;
 use snafu::{ensure, ResultExt};
 use ssd1306::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
-extern crate peach_oled;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-
 use std::process;
+
+use log::error;
 
 fn main() {
     // initialize the logger


### PR DESCRIPTION
Remove `extern` statements and replace with `use` where required.